### PR TITLE
Allow acceptable difference secondary serial numbers can be behind master

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,13 @@ It is written in Shell (Bash).
 
 # Usage
 
-	check_dnsserials -d DOMAIN [-H DNS-MASTER] [-S DNS-SLAVES] [ -s SOA-SERIAL] [-w FAILS] [-c FAILS] [ -h -v ]
+	check_dnsserials -d DOMAIN [-H DNS-MASTER] [-S DNS-SLAVES] [ -s SOA-SERIAL] [-w FAILS] [-c FAILS] [-t TOLERANCE ] [ -h -v ]
 
 	DNS-MASTER: The master to get all main informations from
 	DNS-SLAVES: The slaves to compare with the master's serial
 	SOA-SERIAL: The serial number used to compare all DNS slaves (not recommended to set)
 	FAILS: The amount of DNS servers allowed having another serial (=> amount of dns servers not in sync) (defaults to 0)
+    TOLERANCE: The acceptable difference secondary serial numbers can be behind master. Useful for DDNS sites with a lot of devices
 
 	If any of DNS-MASTER, DNS-SLAVES or SOA-SERIAL is unset, it'll get queried from the DNS system.
 

--- a/check_dnsserials
+++ b/check_dnsserials
@@ -25,7 +25,7 @@
 export PATH="/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin"
 PROGNAME="$(basename "${0}")"
 PROGPATH="$(sed -e 's,[\\/][^\\/][^\\/]*$,,' <<< "${0}")"
-REVISION="1.1.0"
+REVISION="1.2.1"
 COMMAND_DIG="$(command -v "${COMMAND_DIG:-dig}")"
 
 # source a utils.sh from nagios-plugins
@@ -129,7 +129,7 @@ verbose "Domain ${domain}"
 	|| error "Warning value has to be positive."
 [ -z "${warn}" ] || [ -z "${crit}" ] || [ "${warn}" -le "${crit}" ] \
 	|| error "Warning value has to be lower than critical."
-[ -z "${tolerance}" ] || [ "${tolerance}" -ge 0 ] \
+[ -z "${tolerance}" ] || [ "${tolerance}" -gt 0 ] \
 	|| error "Tolerance value has to be positive."
 
 # if no master given, use the standard DNS to determine the master
@@ -166,26 +166,26 @@ for server in ${slaves}; do
 	if [ "x${serial_slave}" = "x${serial}" ]; then
 		verbose "OK:  ${domain} ${server} ${serial}"
 		else
-                        if [ -n "${tolerance}" ]; then
-			        if [ $((${serial} - ${serial_slave})) -lt 0 ]; then
-			                verbose "CRITIAL: ${domain} ${server} ${serial} < ${serial_slave}"
-			                fails=$((fails + 1))
-			                failedServers+=(${server})
-			                debug "Incrementing failed states to ${fails}"
-			        elif [ $((${serial} - ${serial_slave})) -gt ${tolerance} ]; then
-			                verbose "BAD: ${domain} ${server} ${serial} - ${serial_slave} > ${tolerance}"
-			                fails=$((fails + 1))
-			                failedServers+=(${server})
-			                debug "Incrementing failed states to ${fails}"
+			if [[ ${tolerance} -gt 0 ]]; then
+				if [ $((${serial} - ${serial_slave})) -lt 0 ]; then
+					verbose "CRITIAL: ${domain} ${server} ${serial} < ${serial_slave}"
+					fails=$((fails + 1))
+					failedServers+=(${server})
+					debug "Incrementing failed states to ${fails}"
+				elif [ $((${serial} - ${serial_slave})) -gt ${tolerance} ]; then
+					verbose "BAD: ${domain} ${server} ${serial} - ${serial_slave} > ${tolerance}"
+					fails=$((fails + 1))
+					failedServers+=(${server})
+					debug "Incrementing failed states to ${fails}"
 				else
-		                        verbose "OK:  ${domain} ${server} ${serial} - ${serial_slave} < ${tolerance}"
+					verbose "OK:  ${domain} ${server} ${serial} - ${serial_slave} < ${tolerance}"
 				fi
-                        else
-			        verbose "BAD: ${domain} ${server} ${serial_slave}"
-			        fails=$((fails + 1))
-			        failedServers+=(${server})
-			        debug "Incrementing failed states to ${fails}"
-                        fi
+			else
+				verbose "BAD: ${domain} ${server} ${serial_slave}"
+				fails=$((fails + 1))
+				failedServers+=(${server})
+				debug "Incrementing failed states to ${fails}"
+			fi
 	fi
 done
 

--- a/check_dnsserials
+++ b/check_dnsserials
@@ -34,6 +34,7 @@ COMMAND_DIG="$(command -v "${COMMAND_DIG:-dig}")"
 # avoid problems with the package-manager
 for script in \
 	"${PROGPATH}/utils.sh" \
+	/usr/local/nagios/libexec/utils.sh \
 	/usr/lib/nagios/plugins/utils.sh \
 	/usr/lib/monitoring-plugins/utils.sh \
 	; do
@@ -55,12 +56,13 @@ verbose(){ [ "${verbose}" -lt 1 ] || printf '%s\n' "${@}"; }
 
 usage(){
 	cat <<-FIN
-	usage: ${PROGNAME} -d DOMAIN [-H DNS-MASTER] [-S DNS-SLAVES] [ -s SOA-SERIAL] [-w FAILS] [-c FAILS] [ -h -v ]
+	usage: ${PROGNAME} -d DOMAIN [-H DNS-MASTER] [-S DNS-SLAVES] [ -s SOA-SERIAL] [-w FAILS] [-c FAILS] [-t TOLERANCE ] [ -h -v ]
 
 	DNS-MASTER: The master to get all main informations from
 	DNS-SLAVES: The slaves to compare with the master's serial
 	SOA-SERIAL: The serial number used to compare all DNS slaves (not recommended to set)
 	FAILS: The amount of DNS servers allowed having another serial (=> amount of dns servers not in sync) (defaults to 0)
+	TOLERANCE: The acceptable difference secondary serial numbers can be behind master. Useful for DDNS sites with a lot of devices
 
 	If any of DNS-MASTER, DNS-SLAVES or SOA-SERIAL is unset, it'll get queried from the DNS system.
 	FIN
@@ -71,10 +73,11 @@ master=""
 serial=""
 verbose=0
 fails=0
+tolerance=0
 state="${STATE_UNKNOWN}"
 failedServers=()
 
-while getopts ":vhd:H:S:s:c:w:" opt; do
+while getopts ":vhd:H:S:s:c:w:t:" opt; do
 	case "${opt}" in
 		v)
 			verbose=$((verbose + 1))
@@ -100,6 +103,9 @@ while getopts ":vhd:H:S:s:c:w:" opt; do
 		w)
 			warn="${OPTARG}"
 			;;
+		t)
+			tolerance="${OPTARG}"
+			;;
 		\?)
 			error "Invalid option: -${OPTARG}" \
 				"Use '-h' to acquire usage output."
@@ -123,6 +129,8 @@ verbose "Domain ${domain}"
 	|| error "Warning value has to be positive."
 [ -z "${warn}" ] || [ -z "${crit}" ] || [ "${warn}" -le "${crit}" ] \
 	|| error "Warning value has to be lower than critical."
+[ -z "${tolerance}" ] || [ "${tolerance}" -ge 0 ] \
+	|| error "Tolerance value has to be positive."
 
 # if no master given, use the standard DNS to determine the master
 if [ -z "${master}" ]; then
@@ -158,10 +166,26 @@ for server in ${slaves}; do
 	if [ "x${serial_slave}" = "x${serial}" ]; then
 		verbose "OK:  ${domain} ${server} ${serial}"
 		else
-			verbose "BAD: ${domain} ${server} ${serial_slave}"
-			fails=$((fails + 1))
-			failedServers+=(${server})
-			debug "Incrementing failed states to ${fails}"
+                        if [ -n "${tolerance}" ]; then
+			        if [ $((${serial} - ${serial_slave})) -lt 0 ]; then
+			                verbose "CRITIAL: ${domain} ${server} ${serial} < ${serial_slave}"
+			                fails=$((fails + 1))
+			                failedServers+=(${server})
+			                debug "Incrementing failed states to ${fails}"
+			        elif [ $((${serial} - ${serial_slave})) -gt ${tolerance} ]; then
+			                verbose "BAD: ${domain} ${server} ${serial} - ${serial_slave} > ${tolerance}"
+			                fails=$((fails + 1))
+			                failedServers+=(${server})
+			                debug "Incrementing failed states to ${fails}"
+				else
+		                        verbose "OK:  ${domain} ${server} ${serial} - ${serial_slave} < ${tolerance}"
+				fi
+                        else
+			        verbose "BAD: ${domain} ${server} ${serial_slave}"
+			        fails=$((fails + 1))
+			        failedServers+=(${server})
+			        debug "Incrementing failed states to ${fails}"
+                        fi
 	fi
 done
 


### PR DESCRIPTION
Hello

Thanks for your great check - it has saved my bacon a few times...

We have an environment where DDNS updates from user devices makes check_dnsserials quite noisy during the day because DDNS will increment serials in real time, but the power DNS back end will only notify secondaries each minute. Morning and lunch times as devices register on the network means the secondaries are always catching up

In this pull request, I have added the idea of a "tolerance" of a difference between serial numbers of the primary and secondaries that we accept because we know the system will eventually converge. The check will also look out for when the serial of the secondaries is greater than the primary. We've actually had this happen with cached web pages of Power DNS Admin writing old zones down

I've been running with a tolerance of 5 and our noise has stopped, and thought it might be useful to other users of the check

I've tried to replicate your style, but feel free to offer suggestions before you accept this PR

Thanks again for your check

Regards

John